### PR TITLE
TOAD package handling

### DIFF
--- a/src/main/java/com/googlecode/scheme2ddl/TypeNamesUtil.java
+++ b/src/main/java/com/googlecode/scheme2ddl/TypeNamesUtil.java
@@ -15,12 +15,15 @@ public class TypeNamesUtil {
      * @return type name for using in  DBMS_METADATA package
      */
     public static String map2TypeForDBMS(String type) {
+		FileNameConstructor fileNameConstructor;
         if (type.contains("DATABASE LINK"))
             return "DB_LINK";
         if (type.equals("JOB"))
             return "PROCOBJ";
 		if (type.equals("SCHEDULE"))
             return "PROCOBJ";
+		if (type.equals("PACKAGE"))
+            return "PACKAGE_SPEC";
         return type.replace(" ", "_");
     }
 

--- a/src/main/resources/scheme2ddl.config.xml
+++ b/src/main/resources/scheme2ddl.config.xml
@@ -105,10 +105,10 @@
         <entry key="VIEW">
             <value>vw</value>
         </entry>
-        <entry key="PACKAGE">   <!--todo is not the same as Package Specs of TOAD -->
+        <entry key="PACKAGE">
             <value>pks</value>
         </entry>
-        <entry key="PACKAGE BODY">
+        <entry key="PACKAGE_BODY">
             <value>pkb</value>
         </entry>
     </util:map>
@@ -187,7 +187,7 @@
                 <value>OBJECT_GRANT</value>
             </set>
         </entry>
-        <entry key="PACKAGE">
+        <entry key="PACKAGE BODY">
             <set>
                 <value>OBJECT_GRANT</value>
             </set>
@@ -227,7 +227,7 @@
         <entry key="LOB"><set><value>*</value></set></entry>
 
         <!--Excluded, because all them persist in PACKAGE, TYPE and TABLE -->
-        <entry key="PACKAGE BODY"><set><value>*</value></set></entry>
+        <!--<entry key="PACKAGE BODY"><set><value>*</value></set></entry>-->
         <entry key="TYPE BODY"><set><value>*</value></set></entry>
         <entry key="INDEX"><set><value>*</value></set></entry>
         <!--For removing system types http://www.sql.ru/forum/actualthread.aspx?bid=3&tid=542661&hl=-->


### PR DESCRIPTION
If extensionMap is set to toad, the SPEC files will not contain the body
anymore. Package Spec files are exported to "packages" folders, and
package body to package_bodies.