### PR TITLE
Export refresh groups even without select_catalog_role

### DIFF
--- a/src/main/java/com/googlecode/scheme2ddl/UserObjectProcessor.java
+++ b/src/main/java/com/googlecode/scheme2ddl/UserObjectProcessor.java
@@ -71,6 +71,9 @@ public class UserObjectProcessor implements ItemProcessor<UserObject, UserObject
             if (userObject.getType().equals("PUBLIC DATABASE LINK")) {
                 return userObjectDao.findDDLInPublicScheme(map2TypeForDBMS(userObject.getType()), userObject.getName());
             }
+			if (userObject.getType().equals("REFRESH_GROUP")) {
+                return userObjectDao.findRefGroupDDL(userObject.getType(), userObject.getName());
+            }
             String res = userObjectDao.findPrimaryDDL(map2TypeForDBMS(userObject.getType()), userObject.getName());
             Set<String> dependedTypes = dependencies.get(userObject.getType());
             if (dependedTypes != null) {

--- a/src/main/java/com/googlecode/scheme2ddl/dao/UserObjectDao.java
+++ b/src/main/java/com/googlecode/scheme2ddl/dao/UserObjectDao.java
@@ -26,5 +26,7 @@ public interface UserObjectDao {
     String findDDLInPublicScheme(String type, String name);
 
     String findDbmsJobDDL(String name);
+	
+	String findRefGroupDDL(String type, String name);
 
 }


### PR DESCRIPTION
Use a different mechanism for non dba users, because get_ddl failed on refresh groups.
Note: This will work for Oracle 11g R2 upwards because of the listagg function usage.