### PR TITLE
Added includes section + full name matching

### DIFF
--- a/src/main/java/com/googlecode/scheme2ddl/domain/UserObject.java
+++ b/src/main/java/com/googlecode/scheme2ddl/domain/UserObject.java
@@ -63,4 +63,9 @@ public class UserObject {
                 ", ddl='" + ddl + '\'' +
                 '}';
     }
+    
+    public String getFullName()
+	{
+		return schema + "." + name;
+	}
 }

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -52,6 +52,7 @@
         <property name="dependencies" ref="dependencies"/>
         <property name="stopOnWarning" value="false"/>
         <property name="replaceSequenceValues" value="false"/>
+        <property name="includes" ref="includes"/>
     </bean>
 
 


### PR DESCRIPTION
Hi,

I added the include section in confuguration file, that allows to include excluded objects.

Also, object name to pattern matching extended for full object name. 
I mean: full_object_name := schema_name.object_name

A hope these improvements would be useful for base fork.