### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,17 @@ before_install:
  # - docker inspect oracle
  # - docker ps -a
   - echo "Wait to allow Oracle to be initialized"
-  - travis_wait sleep 10
+  - sleep 10
   - docker top oracle
-  - travis_wait sleep 10
+  - sleep 10
   - docker top oracle
-  - travis_wait sleep 10
+  - sleep 10
   - docker top oracle
-  - travis_wait sleep 10
+  - sleep 10
   - docker top oracle
-  - travis_wait sleep 10
+  - sleep 10
   - docker top oracle
-  - travis_wait sleep 10
+  - sleep 10
   - docker top oracle
 
 script:
@@ -31,3 +31,7 @@ script:
 
 after_success:
   - mvn coveralls:report -Dcoveralls.repoToken=$COVERALLS_REPO_TOKEN
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
